### PR TITLE
fix: add CRM Objects to configuration clients

### DIFF
--- a/lib/hubspot-api-client.rb
+++ b/lib/hubspot-api-client.rb
@@ -523,6 +523,7 @@ module Hubspot
       'Crm::Extensions::Cards',
       'Crm::Imports',
       'Crm::LineItems',
+      'Crm::Objects',
       'Crm::Owners',
       'Crm::Pipelines',
       'Crm::Products',


### PR DESCRIPTION
Hi! I use the master branch of this gem for My Rails application.   
The reason for this is that I want to use a CRM object API.  

# issue
I have Initialized `Hubspot::Crm::Objects::SearchApi` class, not configured api key.

# Root Cause / Fix
Because newly added `Crm::Objects` was not included in the CLIENTS constants, so the configuration was not reflected.
