### PR TITLE
Fix compatibility issues with ruby 1.9 (fixes #59)

### DIFF
--- a/hubspot-api-client.gemspec
+++ b/hubspot-api-client.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 1.9"
 
-  s.add_runtime_dependency 'faraday', '>= 0.14.0'
-  s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
+  s.add_runtime_dependency 'faraday', '>= 0.9.1'
+  s.add_runtime_dependency 'json', '>= 1.8.6'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'

--- a/lib/hubspot-api-client.rb
+++ b/lib/hubspot-api-client.rb
@@ -570,7 +570,7 @@ module Hubspot
       return Configuration.default unless block_given?
       yield(Configuration.default)
       CLIENTS.each do |client_class_name|
-        config_class = Hubspot.const_get("#{client_class_name}::Configuration")
+        config_class = "#{client_class_name}::Configuration".split("::").inject(Hubspot) { |n,c| n.const_get c }
         yield(config_class.default)
       end
       Configuration.default

--- a/lib/hubspot/codegen/cms/audit-logs/api_client.rb
+++ b/lib/hubspot/codegen/cms/audit-logs/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/cms/audit-logs/api_client.rb
+++ b/lib/hubspot/codegen/cms/audit-logs/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/cms/domains/api_client.rb
+++ b/lib/hubspot/codegen/cms/domains/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/cms/domains/api_client.rb
+++ b/lib/hubspot/codegen/cms/domains/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/cms/hubdb/api_client.rb
+++ b/lib/hubspot/codegen/cms/hubdb/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/cms/hubdb/api_client.rb
+++ b/lib/hubspot/codegen/cms/hubdb/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/cms/performance/api_client.rb
+++ b/lib/hubspot/codegen/cms/performance/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/cms/performance/api_client.rb
+++ b/lib/hubspot/codegen/cms/performance/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/cms/site-search/api_client.rb
+++ b/lib/hubspot/codegen/cms/site-search/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/cms/site-search/api_client.rb
+++ b/lib/hubspot/codegen/cms/site-search/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/cms/url-redirects/api_client.rb
+++ b/lib/hubspot/codegen/cms/url-redirects/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/cms/url-redirects/api_client.rb
+++ b/lib/hubspot/codegen/cms/url-redirects/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/associations/api_client.rb
+++ b/lib/hubspot/codegen/crm/associations/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/associations/api_client.rb
+++ b/lib/hubspot/codegen/crm/associations/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/companies/api_client.rb
+++ b/lib/hubspot/codegen/crm/companies/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/companies/api_client.rb
+++ b/lib/hubspot/codegen/crm/companies/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/contacts/api_client.rb
+++ b/lib/hubspot/codegen/crm/contacts/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/contacts/api_client.rb
+++ b/lib/hubspot/codegen/crm/contacts/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/deals/api_client.rb
+++ b/lib/hubspot/codegen/crm/deals/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/deals/api_client.rb
+++ b/lib/hubspot/codegen/crm/deals/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/extensions/cards/api_client.rb
+++ b/lib/hubspot/codegen/crm/extensions/cards/api_client.rb
@@ -99,8 +99,7 @@ module Hubspot
                 else
                   fail ApiError.new(:code => response.status,
                                     :response_headers => response.headers,
-                                    :response_body => response.body),
-                       response.reason_phrase
+                                    :response_body => response.body)
                 end
               end
             rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/extensions/cards/api_client.rb
+++ b/lib/hubspot/codegen/crm/extensions/cards/api_client.rb
@@ -74,8 +74,8 @@ module Hubspot
                     max: opts[:max_retries],
                     interval: opts[:seconds_delay],
                     retry_statuses: statuses,
-                    methods: %i[post delete get head options put],
-                    retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                    methods: [:post, :delete, :get, :head, :options, :put],
+                    retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                   }
                   conn.request :retry, retry_options
                 end

--- a/lib/hubspot/codegen/crm/imports/api_client.rb
+++ b/lib/hubspot/codegen/crm/imports/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/imports/api_client.rb
+++ b/lib/hubspot/codegen/crm/imports/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/line_items/api_client.rb
+++ b/lib/hubspot/codegen/crm/line_items/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/line_items/api_client.rb
+++ b/lib/hubspot/codegen/crm/line_items/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/objects/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/objects/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/owners/api_client.rb
+++ b/lib/hubspot/codegen/crm/owners/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/owners/api_client.rb
+++ b/lib/hubspot/codegen/crm/owners/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/pipelines/api_client.rb
+++ b/lib/hubspot/codegen/crm/pipelines/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/pipelines/api_client.rb
+++ b/lib/hubspot/codegen/crm/pipelines/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/products/api_client.rb
+++ b/lib/hubspot/codegen/crm/products/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/products/api_client.rb
+++ b/lib/hubspot/codegen/crm/products/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/properties/api_client.rb
+++ b/lib/hubspot/codegen/crm/properties/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/properties/api_client.rb
+++ b/lib/hubspot/codegen/crm/properties/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/quotes/api_client.rb
+++ b/lib/hubspot/codegen/crm/quotes/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/quotes/api_client.rb
+++ b/lib/hubspot/codegen/crm/quotes/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/schemas/api_client.rb
+++ b/lib/hubspot/codegen/crm/schemas/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/schemas/api_client.rb
+++ b/lib/hubspot/codegen/crm/schemas/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/tickets/api_client.rb
+++ b/lib/hubspot/codegen/crm/tickets/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/tickets/api_client.rb
+++ b/lib/hubspot/codegen/crm/tickets/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/crm/timeline/api_client.rb
+++ b/lib/hubspot/codegen/crm/timeline/api_client.rb
@@ -98,8 +98,7 @@ module Hubspot
               else
                 fail ApiError.new(:code => response.status,
                                   :response_headers => response.headers,
-                                  :response_body => response.body),
-                     response.reason_phrase
+                                  :response_body => response.body)
               end
             end
           rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/crm/timeline/api_client.rb
+++ b/lib/hubspot/codegen/crm/timeline/api_client.rb
@@ -73,8 +73,8 @@ module Hubspot
                   max: opts[:max_retries],
                   interval: opts[:seconds_delay],
                   retry_statuses: statuses,
-                  methods: %i[post delete get head options put],
-                  retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                  methods: [:post, :delete, :get, :head, :options, :put],
+                  retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
                 }
                 conn.request :retry, retry_options
               end

--- a/lib/hubspot/codegen/oauth/api_client.rb
+++ b/lib/hubspot/codegen/oauth/api_client.rb
@@ -97,8 +97,7 @@ module Hubspot
             else
               fail ApiError.new(:code => response.status,
                                 :response_headers => response.headers,
-                                :response_body => response.body),
-                   response.reason_phrase
+                                :response_body => response.body)
             end
           end
         rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/oauth/api_client.rb
+++ b/lib/hubspot/codegen/oauth/api_client.rb
@@ -72,8 +72,8 @@ module Hubspot
                 max: opts[:max_retries],
                 interval: opts[:seconds_delay],
                 retry_statuses: statuses,
-                methods: %i[post delete get head options put],
-                retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                methods: [:post, :delete, :get, :head, :options, :put],
+                retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
               }
               conn.request :retry, retry_options
             end

--- a/lib/hubspot/codegen/webhooks/api_client.rb
+++ b/lib/hubspot/codegen/webhooks/api_client.rb
@@ -97,8 +97,7 @@ module Hubspot
             else
               fail ApiError.new(:code => response.status,
                                 :response_headers => response.headers,
-                                :response_body => response.body),
-                   response.reason_phrase
+                                :response_body => response.body)
             end
           end
         rescue Faraday::TimeoutError

--- a/lib/hubspot/codegen/webhooks/api_client.rb
+++ b/lib/hubspot/codegen/webhooks/api_client.rb
@@ -72,8 +72,8 @@ module Hubspot
                 max: opts[:max_retries],
                 interval: opts[:seconds_delay],
                 retry_statuses: statuses,
-                methods: %i[post delete get head options put],
-                retry_block: -> (env, options, retries, exc) { opts[:retry_block].call }
+                methods: [:post, :delete, :get, :head, :options, :put],
+                retry_block: ->(env, options, retries, exc) { opts[:retry_block].call }
               }
               conn.request :retry, retry_options
             end

--- a/lib/hubspot/exceptions.rb
+++ b/lib/hubspot/exceptions.rb
@@ -2,7 +2,12 @@ module Hubspot
   class ConfigurationError < StandardError; end
 
   class InvalidSignatureError < StandardError
-    def initialize(msg: nil, signature: nil, signature_version: nil, hash_result: nil)
+    def initialize(options = {})
+      msg = options.fetch(:msg, nil)
+      signature = options.fetch(:signature, nil)
+      signature_version = options.fetch(:signature_version, nil)
+      hash_result = options.fetch(:hash_result, nil)
+      
       @signature = signature
       @signature_version = signature_version
       @hash_result = hash_result

--- a/lib/hubspot/helpers/webhooks_helper.rb
+++ b/lib/hubspot/helpers/webhooks_helper.rb
@@ -1,14 +1,13 @@
 module Hubspot
   module Helpers
     class WebhooksHelper
-      def self.validate_signature(
-        signature:,
-        client_secret:,
-        http_uri:,
-        request_body:,
-        http_method: 'POST',
-        signature_version: 'v2'
-      )
+      def self.validate_signature(options = {})
+        signature = options.fetch(:signature)
+        client_secret = options.fetch(:client_secret)
+        http_uri = options.fetch(:http_uri)
+        request_body = options.fetch(:request_body)
+        http_method = options.fetch(:http_method, 'POST')
+        signature_version = options.fetch(:signature_version, 'v2')
 
         if signature_version == 'v1'
           source_string = client_secret + request_body.to_s

--- a/lib/hubspot/oauth_helper.rb
+++ b/lib/hubspot/oauth_helper.rb
@@ -2,7 +2,12 @@ module Hubspot
   class OAuthHelper
     AUTHORIZE_URL = 'https://app.hubspot.com/oauth/authorize'.freeze
     class << self
-      def authorize_url(client_id:, redirect_uri:, scope:, optional_scope: [])
+      def authorize_url(options = {})
+        client_id = options.fetch(:client_id)
+        redirect_uri = options.fetch(:redirect_uri)
+        scope = options.fetch(:scope)
+        optional_scope = options.fetch(:optional_scope, [])
+        
         query = URI.encode_www_form(
           client_id: client_id,
           redirect_uri: redirect_uri,


### PR DESCRIPTION
I am using this library in an old project that's still running on ruby 1.9.3 and had to make modifications to support it. Since this library has >= 1.9 in the gemspec, I figured I might open this if there's interest in supporting 1.9 fully.

Totally understand if you'd prefer to instead update gemspec to >= 2.1 or whatever is needed, up to you. Figured I'd open this just in case it's desired, or perhaps it could be added onto a separate branch for 1.9 support.

## Changes

- Replace Keyword Arguments with using a Hash argument
- Replace usage of "%i[]" syntax with arrays of symbols
- Fix issue with const_get not working with nested namespaces in 1.9
- Fix issue with lambda syntax issue caused by space between "-> ("
- Update json and faraday minimum versions in gemspec to versions supporting ruby 1.9

## Notes

* The way that the keyword arguments have been replaced should theoretically be backwards compat? _However_, there is one important note - since I'm using the Hash `fetch` method, if a default value isn't specified and the value is not provided a `KeyError` is thrown. This is slightly different from required Keyword Arguments, where if a required keyword argument is not provided, an `ArgumentError` is thrown. Not sure if that's considered a BC break or not.

* I'm not sure what the impact of downgrading the minimum versions of json and faraday would be, from the testing that I've done working with the package on my project, I have resolved all of the issues I was seeing related to the downgrade in this branch and I have it functioning in my ruby 1.9.3 application.