### PR TITLE
New discovery configuration

### DIFF
--- a/lib/hubspot/client.rb
+++ b/lib/hubspot/client.rb
@@ -2,8 +2,6 @@ require_rel 'discovery'
 
 module Hubspot
   class Client
-    attr_reader :api_key, :access_token
-
     def self.api_modules
       %i[
         automation
@@ -28,25 +26,9 @@ module Hubspot
       'Hubspot::Discovery'
     end
 
-    def configure_api_key
-      Hubspot.configure do |config|
-        config.api_key['hapikey'] = api_key
-      end
-    end
-
-    def configure_access_token
-      Hubspot.configure do |config|
-        config.access_token = access_token
-      end
-    end
-
     def initialize(params)
       raise 'Please, pass :api_key or :access_token' if params[:api_key].nil? && params[:developer_api_key].nil? && params[:access_token].nil?
-      @api_key = params[:api_key] || params[:developer_api_key]
-      @access_token = params[:access_token]
       @params = params
-      configure_api_key if @api_key
-      configure_access_token if @access_token
     end
   end
 end

--- a/lib/hubspot/discovery/base_api_client.rb
+++ b/lib/hubspot/discovery/base_api_client.rb
@@ -12,12 +12,16 @@ module Hubspot
         api.methods.grep(/with_http_info/).map {|elem| elem.to_s.gsub('_with_http_info', '').to_sym }
       end
 
+      def config
+        @config ||= new_config
+      end
+
       def api_client
-        api&.api_client
+        @api_client ||= Kernel.const_get("#{self.class.name.gsub('Discovery::', '').gsub(/(.*)::.*/, '\1')}::ApiClient").new(config)
       end
 
       def api
-        @api ||= Kernel.const_get(codegen_api_class).new
+        @api ||= Kernel.const_get(codegen_api_class).new(api_client)
       end
 
       def get_all(params = {})
@@ -25,6 +29,14 @@ module Hubspot
       end
 
       private
+
+      def new_config
+        config = Kernel.const_get("#{self.class.name.gsub('Discovery::', '').gsub(/(.*)::.*/, '\1')}::Configuration").new
+        config.access_token = base_params[:access_token] if base_params[:access_token]
+        config.api_key['hapikey'] = base_params[:api_key] if base_params[:api_key]
+        config.api_key['hapikey'] = base_params[:developer_api_key] if base_params[:developer_api_key]
+        config
+      end
 
       def codegen_api_class
         self.class.name.gsub('Discovery::', '')

--- a/spec/discovery/base_api_client_spec.rb
+++ b/spec/discovery/base_api_client_spec.rb
@@ -6,6 +6,9 @@ describe 'Hubspot::Discovery::BaseApiClient' do
   end
 
   class Hubspot::SomeApiClass
+    def initialize(api_client)
+    end
+
     def get(test_id, opts = {})
       "got test_id: #{test_id}, opts: #{opts}"
     end
@@ -18,6 +21,11 @@ describe 'Hubspot::Discovery::BaseApiClient' do
     end
 
     def update_with_http_info
+    end
+  end
+
+  class Hubspot::ApiClient
+    def initialize(config)
     end
   end
 


### PR DESCRIPTION
Using new local configurations instead of global default.
There is an issue because of a global configuration: https://github.com/HubSpot/hubspot-api-ruby/issues/150.
Also we should stop using it to drop our old configuration later.