### PR TITLE
Error handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [14.4.0] - 2022-09-27
+### Changed
+
+- handling ApiError by passing a block
+
 ## [14.3.0] - 2022-08-31
 ### Changed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hubspot-api-client (14.3.0)
+    hubspot-api-client (14.4.0)
       json (~> 2.1, >= 2.1.0)
       require_all (~> 3.0.0)
       typhoeus (~> 1.4.0)
@@ -41,13 +41,13 @@ GEM
       rspec-mocks (~> 3.11.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
-    rspec-expectations (3.11.0)
+    rspec-expectations (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-support (3.11.0)
+    rspec-support (3.11.1)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     vcr (3.0.3)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,18 @@ api_response = client.crm.schemas.core_api.create(body: body)
 
 ### Error handling
 
+for new discovery classes since version 14.4
+
+#### You can rescue an ApiError by passing a block to the method
+
+```ruby
+require 'hubspot-api-client'
+
+client = Hubspot::Client.new(access_token: 'your_access_token')
+
+contacts = client.crm.contacts.basic_api.get_page { |error| error.message }
+```
+
 #### You can set number of retry attempts and delay in seconds before retry on specific status code of response.
 
 Available params:

--- a/lib/hubspot/discovery/base_api_client.rb
+++ b/lib/hubspot/discovery/base_api_client.rb
@@ -1,5 +1,4 @@
 require_rel '../helpers/camel_case'
-require 'pry'
 
 module Hubspot
   module Discovery

--- a/lib/hubspot/discovery/base_api_client.rb
+++ b/lib/hubspot/discovery/base_api_client.rb
@@ -1,4 +1,5 @@
 require_rel '../helpers/camel_case'
+require 'pry'
 
 module Hubspot
   module Discovery
@@ -48,13 +49,24 @@ module Hubspot
         codegen_api_class.gsub(/(.*)::.*/, '\1')
       end
 
+      def call_api(api_method, params_to_pass)
+        api.public_send(api_method, *params_to_pass)
+      end
+
+      def call_api_with_rescue(api_method, params_to_pass)
+        error = Kernel.const_get("#{codegen_module_name}::ApiError")
+        call_api(api_method, params_to_pass)
+      rescue error => e
+        yield(e)
+      end
+
       def define_methods
         define_api_methods
       end
       
       def define_api_methods
         api_methods.each do |api_method|
-          self.class.define_method(api_method) do |params = {}|
+          self.class.define_method(api_method) do |params = {}, &block|
             params_with_defaults = params
             params_with_defaults[:opts] ||= {}
             params_with_defaults[:opts][:auth_names] = if base_params[:access_token]
@@ -83,7 +95,8 @@ module Hubspot
               params_with_defaults[param]
             end
 
-            api.public_send(api_method, *params_to_pass)
+            return call_api_with_rescue(api_method, params_to_pass, &block) unless block.nil?
+            call_api(api_method, params_to_pass)
           end
         end
       end

--- a/lib/hubspot/version.rb
+++ b/lib/hubspot/version.rb
@@ -1,3 +1,3 @@
  module Hubspot
-  VERSION = '14.3.0'
+  VERSION = '14.4.0'
  end

--- a/spec/discovery/base_api_client_spec.rb
+++ b/spec/discovery/base_api_client_spec.rb
@@ -22,10 +22,23 @@ describe 'Hubspot::Discovery::BaseApiClient' do
 
     def update_with_http_info
     end
+
+    def raise_error
+      raise Hubspot::ApiError
+    end
+
+    def raise_error_with_http_info
+    end
   end
 
   class Hubspot::ApiClient
     def initialize(config)
+    end
+  end
+
+  class Hubspot::ApiError < ::StandardError
+    def message
+      'test error'
     end
   end
 
@@ -65,6 +78,13 @@ describe 'Hubspot::Discovery::BaseApiClient' do
 
       it { is_expected.to eq('got test_id: test_id_value, opts: {:auth_names=>"oauth2", :limit=>5}') }
     end
+
+    context 'with error handle block' do
+      subject(:get) { client.get(params) { |e| e.message } }
+      let(:params) { {test_id: 'test_id_value', limit: 10} }
+
+      it { is_expected.to eq('got test_id: test_id_value, opts: {:auth_names=>"oauth2", :limit=>10}') }
+    end
   end
   
   describe '#update' do
@@ -93,5 +113,18 @@ describe 'Hubspot::Discovery::BaseApiClient' do
 
       it { is_expected.to eq('updated test_id: test_id_value, name: test_name, email: test_email, opts: {:auth_names=>"oauth2", :limit=>10}') }
     end
+
+    context 'with block' do
+      subject(:update) { client.update(params) { |e| e.message } }
+      let(:params) { {test_id: 'test_id_value', body: body, limit: 10} }
+
+      it { is_expected.to eq('updated test_id: test_id_value, name: test_name, email: test_email, opts: {:auth_names=>"oauth2", :limit=>10}') }
+    end
+  end
+
+  describe '#raise_error' do
+    subject(:raise_error) { client.raise_error { |e| e.message } }
+
+    it { is_expected.to eq('test error') }
   end
 end


### PR DESCRIPTION
Sample of error handle:
```ruby
contacts = client.crm.contacts.basic_api.get_page { |error| error.message }
```
it rescues an ApiError in the current module.