### PR TITLE
Public object API missing from CRM contacts and companies

### DIFF
--- a/lib/hubspot/discovery/crm/companies/api/public_object_api.rb
+++ b/lib/hubspot/discovery/crm/companies/api/public_object_api.rb
@@ -1,0 +1,13 @@
+require_relative '../../../base_api_client'
+
+module Hubspot
+  module Discovery
+    module Crm
+      module Companies
+        class PublicObjectApi
+          include Hubspot::Discovery::BaseApiClient
+        end
+      end
+    end
+  end
+end

--- a/lib/hubspot/discovery/crm/companies/client.rb
+++ b/lib/hubspot/discovery/crm/companies/client.rb
@@ -13,6 +13,7 @@ module Hubspot
               basic
               batch
               search
+              public_object
             ].freeze
           end
         end

--- a/lib/hubspot/discovery/crm/contacts/api/public_object_api.rb
+++ b/lib/hubspot/discovery/crm/contacts/api/public_object_api.rb
@@ -1,0 +1,13 @@
+require_relative '../../../base_api_client'
+
+module Hubspot
+  module Discovery
+    module Crm
+      module Contacts
+        class PublicObjectApi
+          include Hubspot::Discovery::BaseApiClient
+        end
+      end
+    end
+  end
+end

--- a/lib/hubspot/discovery/crm/contacts/client.rb
+++ b/lib/hubspot/discovery/crm/contacts/client.rb
@@ -14,6 +14,7 @@ module Hubspot
               batch
               gdpr
               search
+              public_object
             ].freeze
           end
         end

--- a/spec/discovery/crm/companies/public_object_api_spec.rb
+++ b/spec/discovery/crm/companies/public_object_api_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'Hubspot::Discovery::Crm::Companies::PublicObjectApi' do
+  subject(:public_object_api) { Hubspot::Client.new(access_token: 'test').crm.companies.public_object_api }
+  
+  it { is_expected.to respond_to(:merge) }
+end

--- a/spec/discovery/crm/contacts/public_object_api_spec.rb
+++ b/spec/discovery/crm/contacts/public_object_api_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'Hubspot::Discovery::Crm::Contacts::PublicObjectApi' do
+  subject(:public_object_api) { Hubspot::Client.new(access_token: 'test').crm.contacts.public_object_api }
+  
+  it { is_expected.to respond_to(:merge) }
+end


### PR DESCRIPTION
https://github.com/HubSpot/hubspot-api-ruby/issues/182