### PR TITLE
switch associations query_param to be csv vs multi

### DIFF
--- a/lib/hubspot/codegen/crm/companies/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/companies/api/basic_api.rb
@@ -25,7 +25,7 @@ module Hubspot
         end
         # Archive
         # Move an Object identified by `{companyId}` to the recycling bin.
-        # @param company_id [String] 
+        # @param company_id [String]
         # @param [Hash] opts the optional parameters
         # @return [nil]
         def archive(company_id, opts = {})
@@ -35,7 +35,7 @@ module Hubspot
 
         # Archive
         # Move an Object identified by &#x60;{companyId}&#x60; to the recycling bin.
-        # @param company_id [String] 
+        # @param company_id [String]
         # @param [Hash] opts the optional parameters
         # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
         def archive_with_http_info(company_id, opts = {})
@@ -88,7 +88,7 @@ module Hubspot
 
         # Create
         # Create a company with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard companies is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [SimplePublicObject]
         def create(simple_public_object_input_for_create, opts = {})
@@ -98,7 +98,7 @@ module Hubspot
 
         # Create
         # Create a company with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard companies is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
         def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -156,7 +156,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by `{companyId}`. `{companyId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-        # @param company_id [String] 
+        # @param company_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -171,7 +171,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by &#x60;{companyId}&#x60;. &#x60;{companyId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-        # @param company_id [String] 
+        # @param company_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -194,7 +194,7 @@ module Hubspot
           query_params = opts[:query_params] || {}
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
           query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -270,7 +270,7 @@ module Hubspot
           query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
           # header parameters
@@ -309,8 +309,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by `{companyId}`. `{companyId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param company_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param company_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [SimplePublicObject]
@@ -321,8 +321,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by &#x60;{companyId}&#x60;. &#x60;{companyId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param company_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param company_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/contacts/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/contacts/api/basic_api.rb
@@ -25,7 +25,7 @@ module Hubspot
         end
         # Archive
         # Move an Object identified by `{contactId}` to the recycling bin.
-        # @param contact_id [String] 
+        # @param contact_id [String]
         # @param [Hash] opts the optional parameters
         # @return [nil]
         def archive(contact_id, opts = {})
@@ -35,7 +35,7 @@ module Hubspot
 
         # Archive
         # Move an Object identified by &#x60;{contactId}&#x60; to the recycling bin.
-        # @param contact_id [String] 
+        # @param contact_id [String]
         # @param [Hash] opts the optional parameters
         # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
         def archive_with_http_info(contact_id, opts = {})
@@ -88,7 +88,7 @@ module Hubspot
 
         # Create
         # Create a contact with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard contacts is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [SimplePublicObject]
         def create(simple_public_object_input_for_create, opts = {})
@@ -98,7 +98,7 @@ module Hubspot
 
         # Create
         # Create a contact with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard contacts is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
         def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -156,7 +156,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by `{contactId}`. `{contactId}` refers to the internal object ID.  Control what is returned via the `properties` query param.
-        # @param contact_id [String] 
+        # @param contact_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -171,7 +171,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by &#x60;{contactId}&#x60;. &#x60;{contactId}&#x60; refers to the internal object ID.  Control what is returned via the &#x60;properties&#x60; query param.
-        # @param contact_id [String] 
+        # @param contact_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -194,7 +194,7 @@ module Hubspot
           query_params = opts[:query_params] || {}
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
           query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -270,7 +270,7 @@ module Hubspot
           query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
           # header parameters
@@ -309,8 +309,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by `{contactId}`. `{contactId}` refers to the internal object ID. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param contact_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param contact_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [SimplePublicObject]
@@ -321,8 +321,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by &#x60;{contactId}&#x60;. &#x60;{contactId}&#x60; refers to the internal object ID. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param contact_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param contact_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/deals/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/deals/api/basic_api.rb
@@ -25,7 +25,7 @@ module Hubspot
         end
         # Archive
         # Move an Object identified by `{dealId}` to the recycling bin.
-        # @param deal_id [String] 
+        # @param deal_id [String]
         # @param [Hash] opts the optional parameters
         # @return [nil]
         def archive(deal_id, opts = {})
@@ -35,7 +35,7 @@ module Hubspot
 
         # Archive
         # Move an Object identified by &#x60;{dealId}&#x60; to the recycling bin.
-        # @param deal_id [String] 
+        # @param deal_id [String]
         # @param [Hash] opts the optional parameters
         # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
         def archive_with_http_info(deal_id, opts = {})
@@ -88,7 +88,7 @@ module Hubspot
 
         # Create
         # Create a deal with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard deals is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [SimplePublicObject]
         def create(simple_public_object_input_for_create, opts = {})
@@ -98,7 +98,7 @@ module Hubspot
 
         # Create
         # Create a deal with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard deals is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
         def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -156,7 +156,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by `{dealId}`. `{dealId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-        # @param deal_id [String] 
+        # @param deal_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -171,7 +171,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by &#x60;{dealId}&#x60;. &#x60;{dealId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-        # @param deal_id [String] 
+        # @param deal_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -194,7 +194,7 @@ module Hubspot
           query_params = opts[:query_params] || {}
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
           query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -270,7 +270,7 @@ module Hubspot
           query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
           # header parameters
@@ -309,8 +309,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by `{dealId}`. `{dealId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param deal_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param deal_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [SimplePublicObject]
@@ -321,8 +321,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by &#x60;{dealId}&#x60;. &#x60;{dealId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param deal_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param deal_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/line_items/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/line_items/api/basic_api.rb
@@ -25,7 +25,7 @@ module Hubspot
         end
         # Archive
         # Move an Object identified by `{lineItemId}` to the recycling bin.
-        # @param line_item_id [String] 
+        # @param line_item_id [String]
         # @param [Hash] opts the optional parameters
         # @return [nil]
         def archive(line_item_id, opts = {})
@@ -35,7 +35,7 @@ module Hubspot
 
         # Archive
         # Move an Object identified by &#x60;{lineItemId}&#x60; to the recycling bin.
-        # @param line_item_id [String] 
+        # @param line_item_id [String]
         # @param [Hash] opts the optional parameters
         # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
         def archive_with_http_info(line_item_id, opts = {})
@@ -88,7 +88,7 @@ module Hubspot
 
         # Create
         # Create a line item with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard line items is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [SimplePublicObject]
         def create(simple_public_object_input_for_create, opts = {})
@@ -98,7 +98,7 @@ module Hubspot
 
         # Create
         # Create a line item with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard line items is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
         def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -156,7 +156,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by `{lineItemId}`. `{lineItemId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-        # @param line_item_id [String] 
+        # @param line_item_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -171,7 +171,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by &#x60;{lineItemId}&#x60;. &#x60;{lineItemId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-        # @param line_item_id [String] 
+        # @param line_item_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -194,7 +194,7 @@ module Hubspot
           query_params = opts[:query_params] || {}
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
           query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -270,7 +270,7 @@ module Hubspot
           query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
           # header parameters
@@ -309,8 +309,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by `{lineItemId}`. `{lineItemId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param line_item_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param line_item_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [SimplePublicObject]
@@ -321,8 +321,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by &#x60;{lineItemId}&#x60;. &#x60;{lineItemId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param line_item_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param line_item_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/objects/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/objects/api/basic_api.rb
@@ -25,8 +25,8 @@ module Hubspot
         end
         # Archive
         # Move an Object identified by `{objectId}` to the recycling bin.
-        # @param object_type [String] 
-        # @param object_id [String] 
+        # @param object_type [String]
+        # @param object_id [String]
         # @param [Hash] opts the optional parameters
         # @return [nil]
         def archive(object_type, object_id, opts = {})
@@ -36,8 +36,8 @@ module Hubspot
 
         # Archive
         # Move an Object identified by &#x60;{objectId}&#x60; to the recycling bin.
-        # @param object_type [String] 
-        # @param object_id [String] 
+        # @param object_type [String]
+        # @param object_id [String]
         # @param [Hash] opts the optional parameters
         # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
         def archive_with_http_info(object_type, object_id, opts = {})
@@ -94,8 +94,8 @@ module Hubspot
 
         # Create
         # Create a CRM object with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard objects is provided.
-        # @param object_type [String] 
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param object_type [String]
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [SimplePublicObject]
         def create(object_type, simple_public_object_input_for_create, opts = {})
@@ -105,8 +105,8 @@ module Hubspot
 
         # Create
         # Create a CRM object with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard objects is provided.
-        # @param object_type [String] 
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param object_type [String]
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
         def create_with_http_info(object_type, simple_public_object_input_for_create, opts = {})
@@ -168,8 +168,8 @@ module Hubspot
 
         # Read
         # Read an Object identified by `{objectId}`. `{objectId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-        # @param object_type [String] 
-        # @param object_id [String] 
+        # @param object_type [String]
+        # @param object_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -184,8 +184,8 @@ module Hubspot
 
         # Read
         # Read an Object identified by &#x60;{objectId}&#x60;. &#x60;{objectId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-        # @param object_type [String] 
-        # @param object_id [String] 
+        # @param object_type [String]
+        # @param object_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -212,7 +212,7 @@ module Hubspot
           query_params = opts[:query_params] || {}
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
           query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -252,7 +252,7 @@ module Hubspot
 
         # List
         # Read a page of objects. Control what is returned via the `properties` query param.
-        # @param object_type [String] 
+        # @param object_type [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Integer] :limit The maximum number of results to display per page. (default to 10)
         # @option opts [String] :after The paging cursor token of the last successfully read resource will be returned as the &#x60;paging.next.after&#x60; JSON property of a paged response containing more results.
@@ -268,7 +268,7 @@ module Hubspot
 
         # List
         # Read a page of objects. Control what is returned via the &#x60;properties&#x60; query param.
-        # @param object_type [String] 
+        # @param object_type [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Integer] :limit The maximum number of results to display per page. (default to 10)
         # @option opts [String] :after The paging cursor token of the last successfully read resource will be returned as the &#x60;paging.next.after&#x60; JSON property of a paged response containing more results.
@@ -294,7 +294,7 @@ module Hubspot
           query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
           # header parameters
@@ -333,9 +333,9 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by `{objectId}`. `{objectId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param object_type [String] 
-        # @param object_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param object_type [String]
+        # @param object_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [SimplePublicObject]
@@ -346,9 +346,9 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by &#x60;{objectId}&#x60;. &#x60;{objectId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param object_type [String] 
-        # @param object_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param object_type [String]
+        # @param object_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/objects/calls/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/objects/calls/api/basic_api.rb
@@ -26,7 +26,7 @@ module Hubspot
           end
           # Archive
           # Move an Object identified by `{callId}` to the recycling bin.
-          # @param call_id [String] 
+          # @param call_id [String]
           # @param [Hash] opts the optional parameters
           # @return [nil]
           def archive(call_id, opts = {})
@@ -36,7 +36,7 @@ module Hubspot
 
           # Archive
           # Move an Object identified by &#x60;{callId}&#x60; to the recycling bin.
-          # @param call_id [String] 
+          # @param call_id [String]
           # @param [Hash] opts the optional parameters
           # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
           def archive_with_http_info(call_id, opts = {})
@@ -89,7 +89,7 @@ module Hubspot
 
           # Create
           # Create a call with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard calls is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [SimplePublicObject]
           def create(simple_public_object_input_for_create, opts = {})
@@ -99,7 +99,7 @@ module Hubspot
 
           # Create
           # Create a call with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard calls is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
           def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -157,7 +157,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by `{callId}`. `{callId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-          # @param call_id [String] 
+          # @param call_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -172,7 +172,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by &#x60;{callId}&#x60;. &#x60;{callId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-          # @param call_id [String] 
+          # @param call_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -195,7 +195,7 @@ module Hubspot
             query_params = opts[:query_params] || {}
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
             query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -271,7 +271,7 @@ module Hubspot
             query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
             # header parameters
@@ -310,8 +310,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by `{callId}`. `{callId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param call_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param call_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [SimplePublicObject]
@@ -322,8 +322,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by &#x60;{callId}&#x60;. &#x60;{callId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param call_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param call_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/objects/communications/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/objects/communications/api/basic_api.rb
@@ -26,7 +26,7 @@ module Hubspot
           end
           # Archive
           # Move an Object identified by `{communicationId}` to the recycling bin.
-          # @param communication_id [String] 
+          # @param communication_id [String]
           # @param [Hash] opts the optional parameters
           # @return [nil]
           def archive(communication_id, opts = {})
@@ -36,7 +36,7 @@ module Hubspot
 
           # Archive
           # Move an Object identified by &#x60;{communicationId}&#x60; to the recycling bin.
-          # @param communication_id [String] 
+          # @param communication_id [String]
           # @param [Hash] opts the optional parameters
           # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
           def archive_with_http_info(communication_id, opts = {})
@@ -89,7 +89,7 @@ module Hubspot
 
           # Create
           # Create a communication with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard Communications is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [SimplePublicObject]
           def create(simple_public_object_input_for_create, opts = {})
@@ -99,7 +99,7 @@ module Hubspot
 
           # Create
           # Create a communication with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard Communications is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
           def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -157,7 +157,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by `{communicationId}`. `{communicationId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-          # @param communication_id [String] 
+          # @param communication_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -172,7 +172,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by &#x60;{communicationId}&#x60;. &#x60;{communicationId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-          # @param communication_id [String] 
+          # @param communication_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -195,7 +195,7 @@ module Hubspot
             query_params = opts[:query_params] || {}
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
             query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -271,7 +271,7 @@ module Hubspot
             query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
             # header parameters
@@ -310,8 +310,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by `{communicationId}`. `{communicationId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param communication_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param communication_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [SimplePublicObject]
@@ -322,8 +322,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by &#x60;{communicationId}&#x60;. &#x60;{communicationId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param communication_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param communication_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/objects/emails/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/objects/emails/api/basic_api.rb
@@ -26,7 +26,7 @@ module Hubspot
           end
           # Archive
           # Move an Object identified by `{emailId}` to the recycling bin.
-          # @param email_id [String] 
+          # @param email_id [String]
           # @param [Hash] opts the optional parameters
           # @return [nil]
           def archive(email_id, opts = {})
@@ -36,7 +36,7 @@ module Hubspot
 
           # Archive
           # Move an Object identified by &#x60;{emailId}&#x60; to the recycling bin.
-          # @param email_id [String] 
+          # @param email_id [String]
           # @param [Hash] opts the optional parameters
           # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
           def archive_with_http_info(email_id, opts = {})
@@ -89,7 +89,7 @@ module Hubspot
 
           # Create
           # Create a email with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard emails is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [SimplePublicObject]
           def create(simple_public_object_input_for_create, opts = {})
@@ -99,7 +99,7 @@ module Hubspot
 
           # Create
           # Create a email with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard emails is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
           def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -157,7 +157,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by `{emailId}`. `{emailId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-          # @param email_id [String] 
+          # @param email_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -172,7 +172,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by &#x60;{emailId}&#x60;. &#x60;{emailId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-          # @param email_id [String] 
+          # @param email_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -195,7 +195,7 @@ module Hubspot
             query_params = opts[:query_params] || {}
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
             query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -271,7 +271,7 @@ module Hubspot
             query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
             # header parameters
@@ -310,8 +310,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by `{emailId}`. `{emailId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param email_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param email_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [SimplePublicObject]
@@ -322,8 +322,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by &#x60;{emailId}&#x60;. &#x60;{emailId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param email_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param email_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/objects/feedback_submissions/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/objects/feedback_submissions/api/basic_api.rb
@@ -26,7 +26,7 @@ module Hubspot
           end
           # Archive
           # Move an Object identified by `{feedbackSubmissionId}` to the recycling bin.
-          # @param feedback_submission_id [String] 
+          # @param feedback_submission_id [String]
           # @param [Hash] opts the optional parameters
           # @return [nil]
           def archive(feedback_submission_id, opts = {})
@@ -36,7 +36,7 @@ module Hubspot
 
           # Archive
           # Move an Object identified by &#x60;{feedbackSubmissionId}&#x60; to the recycling bin.
-          # @param feedback_submission_id [String] 
+          # @param feedback_submission_id [String]
           # @param [Hash] opts the optional parameters
           # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
           def archive_with_http_info(feedback_submission_id, opts = {})
@@ -89,7 +89,7 @@ module Hubspot
 
           # Create
           # Create a feedback submission with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard feedback submissions is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [SimplePublicObject]
           def create(simple_public_object_input_for_create, opts = {})
@@ -99,7 +99,7 @@ module Hubspot
 
           # Create
           # Create a feedback submission with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard feedback submissions is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
           def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -157,7 +157,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by `{feedbackSubmissionId}`. `{feedbackSubmissionId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-          # @param feedback_submission_id [String] 
+          # @param feedback_submission_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -172,7 +172,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by &#x60;{feedbackSubmissionId}&#x60;. &#x60;{feedbackSubmissionId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-          # @param feedback_submission_id [String] 
+          # @param feedback_submission_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -195,7 +195,7 @@ module Hubspot
             query_params = opts[:query_params] || {}
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
             query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -271,7 +271,7 @@ module Hubspot
             query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
             # header parameters
@@ -310,8 +310,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by `{feedbackSubmissionId}`. `{feedbackSubmissionId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param feedback_submission_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param feedback_submission_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [SimplePublicObject]
@@ -322,8 +322,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by &#x60;{feedbackSubmissionId}&#x60;. &#x60;{feedbackSubmissionId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param feedback_submission_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param feedback_submission_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/objects/meetings/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/objects/meetings/api/basic_api.rb
@@ -26,7 +26,7 @@ module Hubspot
           end
           # Archive
           # Move an Object identified by `{meetingId}` to the recycling bin.
-          # @param meeting_id [String] 
+          # @param meeting_id [String]
           # @param [Hash] opts the optional parameters
           # @return [nil]
           def archive(meeting_id, opts = {})
@@ -36,7 +36,7 @@ module Hubspot
 
           # Archive
           # Move an Object identified by &#x60;{meetingId}&#x60; to the recycling bin.
-          # @param meeting_id [String] 
+          # @param meeting_id [String]
           # @param [Hash] opts the optional parameters
           # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
           def archive_with_http_info(meeting_id, opts = {})
@@ -89,7 +89,7 @@ module Hubspot
 
           # Create
           # Create a meeting with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard meetings is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [SimplePublicObject]
           def create(simple_public_object_input_for_create, opts = {})
@@ -99,7 +99,7 @@ module Hubspot
 
           # Create
           # Create a meeting with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard meetings is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
           def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -157,7 +157,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by `{meetingId}`. `{meetingId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-          # @param meeting_id [String] 
+          # @param meeting_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -172,7 +172,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by &#x60;{meetingId}&#x60;. &#x60;{meetingId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-          # @param meeting_id [String] 
+          # @param meeting_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -195,7 +195,7 @@ module Hubspot
             query_params = opts[:query_params] || {}
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
             query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -271,7 +271,7 @@ module Hubspot
             query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
             # header parameters
@@ -310,8 +310,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by `{meetingId}`. `{meetingId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param meeting_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param meeting_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [SimplePublicObject]
@@ -322,8 +322,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by &#x60;{meetingId}&#x60;. &#x60;{meetingId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param meeting_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param meeting_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/objects/notes/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/objects/notes/api/basic_api.rb
@@ -26,7 +26,7 @@ module Hubspot
           end
           # Archive
           # Move an Object identified by `{noteId}` to the recycling bin.
-          # @param note_id [String] 
+          # @param note_id [String]
           # @param [Hash] opts the optional parameters
           # @return [nil]
           def archive(note_id, opts = {})
@@ -36,7 +36,7 @@ module Hubspot
 
           # Archive
           # Move an Object identified by &#x60;{noteId}&#x60; to the recycling bin.
-          # @param note_id [String] 
+          # @param note_id [String]
           # @param [Hash] opts the optional parameters
           # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
           def archive_with_http_info(note_id, opts = {})
@@ -89,7 +89,7 @@ module Hubspot
 
           # Create
           # Create a note with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard notes is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [SimplePublicObject]
           def create(simple_public_object_input_for_create, opts = {})
@@ -99,7 +99,7 @@ module Hubspot
 
           # Create
           # Create a note with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard notes is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
           def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -157,7 +157,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by `{noteId}`. `{noteId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-          # @param note_id [String] 
+          # @param note_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -172,7 +172,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by &#x60;{noteId}&#x60;. &#x60;{noteId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-          # @param note_id [String] 
+          # @param note_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -195,7 +195,7 @@ module Hubspot
             query_params = opts[:query_params] || {}
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
             query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -271,7 +271,7 @@ module Hubspot
             query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
             # header parameters
@@ -310,8 +310,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by `{noteId}`. `{noteId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param note_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param note_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [SimplePublicObject]
@@ -322,8 +322,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by &#x60;{noteId}&#x60;. &#x60;{noteId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param note_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param note_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/objects/postal_mail/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/objects/postal_mail/api/basic_api.rb
@@ -26,7 +26,7 @@ module Hubspot
           end
           # Archive
           # Move an Object identified by `{postalMail}` to the recycling bin.
-          # @param postal_mail [String] 
+          # @param postal_mail [String]
           # @param [Hash] opts the optional parameters
           # @return [nil]
           def archive(postal_mail, opts = {})
@@ -36,7 +36,7 @@ module Hubspot
 
           # Archive
           # Move an Object identified by &#x60;{postalMail}&#x60; to the recycling bin.
-          # @param postal_mail [String] 
+          # @param postal_mail [String]
           # @param [Hash] opts the optional parameters
           # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
           def archive_with_http_info(postal_mail, opts = {})
@@ -89,7 +89,7 @@ module Hubspot
 
           # Create
           # Create a postal mail with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard postal mail is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [SimplePublicObject]
           def create(simple_public_object_input_for_create, opts = {})
@@ -99,7 +99,7 @@ module Hubspot
 
           # Create
           # Create a postal mail with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard postal mail is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
           def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -157,7 +157,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by `{postalMail}`. `{postalMail}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-          # @param postal_mail [String] 
+          # @param postal_mail [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -172,7 +172,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by &#x60;{postalMail}&#x60;. &#x60;{postalMail}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-          # @param postal_mail [String] 
+          # @param postal_mail [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -195,7 +195,7 @@ module Hubspot
             query_params = opts[:query_params] || {}
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
             query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -271,7 +271,7 @@ module Hubspot
             query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
             # header parameters
@@ -310,8 +310,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by `{postalMail}`. `{postalMail}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param postal_mail [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param postal_mail [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [SimplePublicObject]
@@ -322,8 +322,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by &#x60;{postalMail}&#x60;. &#x60;{postalMail}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param postal_mail [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param postal_mail [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/objects/tasks/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/objects/tasks/api/basic_api.rb
@@ -26,7 +26,7 @@ module Hubspot
           end
           # Archive
           # Move an Object identified by `{taskId}` to the recycling bin.
-          # @param task_id [String] 
+          # @param task_id [String]
           # @param [Hash] opts the optional parameters
           # @return [nil]
           def archive(task_id, opts = {})
@@ -36,7 +36,7 @@ module Hubspot
 
           # Archive
           # Move an Object identified by &#x60;{taskId}&#x60; to the recycling bin.
-          # @param task_id [String] 
+          # @param task_id [String]
           # @param [Hash] opts the optional parameters
           # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
           def archive_with_http_info(task_id, opts = {})
@@ -89,7 +89,7 @@ module Hubspot
 
           # Create
           # Create a task with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard tasks is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [SimplePublicObject]
           def create(simple_public_object_input_for_create, opts = {})
@@ -99,7 +99,7 @@ module Hubspot
 
           # Create
           # Create a task with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard tasks is provided.
-          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+          # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
           # @param [Hash] opts the optional parameters
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
           def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -157,7 +157,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by `{taskId}`. `{taskId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-          # @param task_id [String] 
+          # @param task_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -172,7 +172,7 @@ module Hubspot
 
           # Read
           # Read an Object identified by &#x60;{taskId}&#x60;. &#x60;{taskId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-          # @param task_id [String] 
+          # @param task_id [String]
           # @param [Hash] opts the optional parameters
           # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
           # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -195,7 +195,7 @@ module Hubspot
             query_params = opts[:query_params] || {}
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
             query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -271,7 +271,7 @@ module Hubspot
             query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
             query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
             query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+            query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
             query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
             # header parameters
@@ -310,8 +310,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by `{taskId}`. `{taskId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param task_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param task_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [SimplePublicObject]
@@ -322,8 +322,8 @@ module Hubspot
 
           # Update
           # Perform a partial update of an Object identified by &#x60;{taskId}&#x60;. &#x60;{taskId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-          # @param task_id [String] 
-          # @param simple_public_object_input [SimplePublicObjectInput] 
+          # @param task_id [String]
+          # @param simple_public_object_input [SimplePublicObjectInput]
           # @param [Hash] opts the optional parameters
           # @option opts [String] :id_property The name of a property whose values are unique for this object type
           # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/products/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/products/api/basic_api.rb
@@ -25,7 +25,7 @@ module Hubspot
         end
         # Archive
         # Move an Object identified by `{productId}` to the recycling bin.
-        # @param product_id [String] 
+        # @param product_id [String]
         # @param [Hash] opts the optional parameters
         # @return [nil]
         def archive(product_id, opts = {})
@@ -35,7 +35,7 @@ module Hubspot
 
         # Archive
         # Move an Object identified by &#x60;{productId}&#x60; to the recycling bin.
-        # @param product_id [String] 
+        # @param product_id [String]
         # @param [Hash] opts the optional parameters
         # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
         def archive_with_http_info(product_id, opts = {})
@@ -88,7 +88,7 @@ module Hubspot
 
         # Create
         # Create a product with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard products is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [SimplePublicObject]
         def create(simple_public_object_input_for_create, opts = {})
@@ -98,7 +98,7 @@ module Hubspot
 
         # Create
         # Create a product with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard products is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
         def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -156,7 +156,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by `{productId}`. `{productId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-        # @param product_id [String] 
+        # @param product_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -171,7 +171,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by &#x60;{productId}&#x60;. &#x60;{productId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-        # @param product_id [String] 
+        # @param product_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -194,7 +194,7 @@ module Hubspot
           query_params = opts[:query_params] || {}
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
           query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -270,7 +270,7 @@ module Hubspot
           query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
           # header parameters
@@ -309,8 +309,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by `{productId}`. `{productId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param product_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param product_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [SimplePublicObject]
@@ -321,8 +321,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by &#x60;{productId}&#x60;. &#x60;{productId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param product_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param product_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/quotes/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/quotes/api/basic_api.rb
@@ -25,7 +25,7 @@ module Hubspot
         end
         # Archive
         # Move an Object identified by `{quoteId}` to the recycling bin.
-        # @param quote_id [String] 
+        # @param quote_id [String]
         # @param [Hash] opts the optional parameters
         # @return [nil]
         def archive(quote_id, opts = {})
@@ -35,7 +35,7 @@ module Hubspot
 
         # Archive
         # Move an Object identified by &#x60;{quoteId}&#x60; to the recycling bin.
-        # @param quote_id [String] 
+        # @param quote_id [String]
         # @param [Hash] opts the optional parameters
         # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
         def archive_with_http_info(quote_id, opts = {})
@@ -88,7 +88,7 @@ module Hubspot
 
         # Create
         # Create a quote with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard quotes is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [SimplePublicObject]
         def create(simple_public_object_input_for_create, opts = {})
@@ -98,7 +98,7 @@ module Hubspot
 
         # Create
         # Create a quote with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard quotes is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
         def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -156,7 +156,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by `{quoteId}`. `{quoteId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-        # @param quote_id [String] 
+        # @param quote_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -171,7 +171,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by &#x60;{quoteId}&#x60;. &#x60;{quoteId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-        # @param quote_id [String] 
+        # @param quote_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -194,7 +194,7 @@ module Hubspot
           query_params = opts[:query_params] || {}
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
           query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -270,7 +270,7 @@ module Hubspot
           query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
           # header parameters
@@ -309,8 +309,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by `{quoteId}`. `{quoteId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param quote_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param quote_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [SimplePublicObject]
@@ -321,8 +321,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by &#x60;{quoteId}&#x60;. &#x60;{quoteId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param quote_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param quote_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers

--- a/lib/hubspot/codegen/crm/tickets/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/tickets/api/basic_api.rb
@@ -25,7 +25,7 @@ module Hubspot
         end
         # Archive
         # Move an Object identified by `{ticketId}` to the recycling bin.
-        # @param ticket_id [String] 
+        # @param ticket_id [String]
         # @param [Hash] opts the optional parameters
         # @return [nil]
         def archive(ticket_id, opts = {})
@@ -35,7 +35,7 @@ module Hubspot
 
         # Archive
         # Move an Object identified by &#x60;{ticketId}&#x60; to the recycling bin.
-        # @param ticket_id [String] 
+        # @param ticket_id [String]
         # @param [Hash] opts the optional parameters
         # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
         def archive_with_http_info(ticket_id, opts = {})
@@ -88,7 +88,7 @@ module Hubspot
 
         # Create
         # Create a ticket with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard tickets is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [SimplePublicObject]
         def create(simple_public_object_input_for_create, opts = {})
@@ -98,7 +98,7 @@ module Hubspot
 
         # Create
         # Create a ticket with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard tickets is provided.
-        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate] 
+        # @param simple_public_object_input_for_create [SimplePublicObjectInputForCreate]
         # @param [Hash] opts the optional parameters
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers
         def create_with_http_info(simple_public_object_input_for_create, opts = {})
@@ -156,7 +156,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by `{ticketId}`. `{ticketId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.
-        # @param ticket_id [String] 
+        # @param ticket_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -171,7 +171,7 @@ module Hubspot
 
         # Read
         # Read an Object identified by &#x60;{ticketId}&#x60;. &#x60;{ticketId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param.  Control what is returned via the &#x60;properties&#x60; query param.
-        # @param ticket_id [String] 
+        # @param ticket_id [String]
         # @param [Hash] opts the optional parameters
         # @option opts [Array<String>] :properties A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
         # @option opts [Array<String>] :properties_with_history A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored.
@@ -194,7 +194,7 @@ module Hubspot
           query_params = opts[:query_params] || {}
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
           query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -270,7 +270,7 @@ module Hubspot
           query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
           # header parameters
@@ -309,8 +309,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by `{ticketId}`. `{ticketId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param ticket_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param ticket_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [SimplePublicObject]
@@ -321,8 +321,8 @@ module Hubspot
 
         # Update
         # Perform a partial update of an Object identified by &#x60;{ticketId}&#x60;. &#x60;{ticketId}&#x60; refers to the internal object ID by default, or optionally any unique property value as specified by the &#x60;idProperty&#x60; query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.
-        # @param ticket_id [String] 
-        # @param simple_public_object_input [SimplePublicObjectInput] 
+        # @param ticket_id [String]
+        # @param simple_public_object_input [SimplePublicObjectInput]
         # @param [Hash] opts the optional parameters
         # @option opts [String] :id_property The name of a property whose values are unique for this object type
         # @return [Array<(SimplePublicObject, Integer, Hash)>] SimplePublicObject data, response status code and response headers


### PR DESCRIPTION
Fixes #262 where query params for associations are getting lost before sending requests. This change uses `:csv` instead of `:multi` when creating the query params.