### PR TITLE
Fix fetch company list endpoint

### DIFF
--- a/lib/hubspot/codegen/crm/lists/models/collection_response_long.rb
+++ b/lib/hubspot/codegen/crm/lists/models/collection_response_long.rb
@@ -39,7 +39,7 @@ module Hubspot
         def self.openapi_types
           {
             :'paging' => :'Paging',
-            :'results' => :'Array<Integer>'
+            :'results' => :'Array<Hash<String, String>>',
           }
         end
 


### PR DESCRIPTION
Fetching companies from a paginated list is currently broken.

The issue is described here in more detail: https://github.com/HubSpot/hubspot-api-ruby/issues/324

This commit implements the fix suggested there which updates the attribute type mapping in CollectionResponseLong to expect an array of hashes.