### PR TITLE
Normalize encode to utf8 for Signature

### DIFF
--- a/lib/hubspot/helpers/signature.rb
+++ b/lib/hubspot/helpers/signature.rb
@@ -31,9 +31,11 @@ module Hubspot
           end
         end
 
+        normalized_request_body = normalize_to_utf8(request_body)
+
         hashed_signature = get_signature(
           client_secret: client_secret,
-          request_body: request_body,
+          request_body: normalized_request_body,
           signature_version: signature_version,
           http_uri: http_uri,
           http_method: http_method,
@@ -58,16 +60,22 @@ module Hubspot
         case signature_version
         when "v1"
           source_string = "#{client_secret}#{request_body}"
-          Digest::SHA2.hexdigest(source_string.encode('utf-8'))
+          Digest::SHA2.hexdigest(normalize_to_utf8(source_string))
         when "v2"
           source_string = "#{client_secret}#{http_method}#{http_uri}#{request_body}"
-          Digest::SHA2.hexdigest(source_string.encode('utf-8'))
+          Digest::SHA2.hexdigest(normalize_to_utf8(source_string))
         when "v3"
           source_string = "#{http_method}#{http_uri}#{request_body}#{timestamp}"
-          OpenSSL::HMAC.base64digest('SHA256', client_secret, source_string.encode('utf-8'))
+          OpenSSL::HMAC.base64digest('SHA256', client_secret, normalize_to_utf8(source_string))
         else
           raise InvalidSignatureVersionError, "Invalid signature version: #{signature_version}"
         end
+      end
+
+      def normalize_to_utf8(str)
+        return "" if str.nil?
+        str = str.force_encoding("UTF-8")
+        str.valid_encoding? ? str : str.encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
       end
 
       def secure_compare(a, b)


### PR DESCRIPTION
- add func `normalize_to_utf8`
https://github.com/HubSpot/hubspot-api-ruby/issues/251