### PR TITLE
Fix `const_get` arguments in api models

### DIFF
--- a/lib/hubspot/discovery/base_api_client.rb
+++ b/lib/hubspot/discovery/base_api_client.rb
@@ -55,7 +55,7 @@ module Hubspot
       end
 
       def require_api_models
-        def (Kernel.const_get(codegen_module_name)).const_get(const)
+        def (Kernel.const_get(codegen_module_name)).const_get(const, *)
           require 'hubspot/helpers/path'
           codegen_module_path = Hubspot::Helpers::Path.new.format(self.name).gsub('hubspot/', 'hubspot/codegen/')
           codegen_model = Hubspot::Helpers::Path.new.format(const)


### PR DESCRIPTION
`Hubspot::Discovery::BaseApiClient#require_api_models` overrides the `const_get` method for generated classes under certain circumstances, but the override only accepts one argument, whereas the original [`Module#const_get`](https://docs.ruby-lang.org/en/2.7.0/Module.html#method-i-const_get) accepts two. This can be a problem when mocking these classes in tests, such as when using `instance_double` from rspec-mocks.

For example:

```
Failure/Error: let(:hubspot_company_object) { instance_double(Hubspot::Crm::Companies::SimplePublicObject) }
     
ArgumentError:
  wrong number of arguments (given 2, expected 1)
```

This fixes that by adding anonymous arguments to the method override, letting the `super` call handle the extra argument.