### PR TITLE
Update rexml from 3.2.5 to 3.4.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     rake (12.3.3)
     rake-release (1.3.0)
       bundler (>= 1.11, < 3)
-    rexml (3.2.5)
+    rexml (3.4.4)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)


### PR DESCRIPTION
Security update for rexml gem (transitive dependency via crack/webmock).
Includes fixes for DoS vulnerabilities https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41946/ and improved XML parsing strictness.
