### PR TITLE
Allow using `json 3.x`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     hubspot-api-client (20.0.0)
-      json (~> 2.1, >= 2.1.0)
-      typhoeus (~> 1.4.0)
+      json (>= 2.1.0)
+      typhoeus (>= 1.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/hubspot-api-client.gemspec
+++ b/hubspot-api-client.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7"
 
   s.add_runtime_dependency 'typhoeus', '>= 1.4.0'
-  s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
+  s.add_runtime_dependency 'json', '>= 2.1.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'

--- a/lib/hubspot/codegen/automation/actions/api_client.rb
+++ b/lib/hubspot/codegen/automation/actions/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/cms/audit_logs/api_client.rb
+++ b/lib/hubspot/codegen/cms/audit_logs/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/cms/blogs/authors/api_client.rb
+++ b/lib/hubspot/codegen/cms/blogs/authors/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/cms/blogs/blog_posts/api_client.rb
+++ b/lib/hubspot/codegen/cms/blogs/blog_posts/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/cms/blogs/tags/api_client.rb
+++ b/lib/hubspot/codegen/cms/blogs/tags/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/cms/domains/api_client.rb
+++ b/lib/hubspot/codegen/cms/domains/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/cms/hubdb/api_client.rb
+++ b/lib/hubspot/codegen/cms/hubdb/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/cms/pages/api_client.rb
+++ b/lib/hubspot/codegen/cms/pages/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/cms/site_search/api_client.rb
+++ b/lib/hubspot/codegen/cms/site_search/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/cms/source_code/api_client.rb
+++ b/lib/hubspot/codegen/cms/source_code/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/cms/url_redirects/api_client.rb
+++ b/lib/hubspot/codegen/cms/url_redirects/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/communication_preferences/api_client.rb
+++ b/lib/hubspot/codegen/communication_preferences/api_client.rb
@@ -245,7 +245,7 @@ module Hubspot
         fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
         begin
-          data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+          data = JSON.parse(body, symbolize_names: true)
         rescue JSON::ParserError => e
           if %w(String Date Time).include?(return_type)
             data = body

--- a/lib/hubspot/codegen/conversations/visitor_identification/api_client.rb
+++ b/lib/hubspot/codegen/conversations/visitor_identification/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/associations/api_client.rb
+++ b/lib/hubspot/codegen/crm/associations/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/associations/schema/api_client.rb
+++ b/lib/hubspot/codegen/crm/associations/schema/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/associations/v4/api_client.rb
+++ b/lib/hubspot/codegen/crm/associations/v4/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/associations/v4/schema/api_client.rb
+++ b/lib/hubspot/codegen/crm/associations/v4/schema/api_client.rb
@@ -248,7 +248,7 @@ module Hubspot
               fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
               begin
-                data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+                data = JSON.parse(body, symbolize_names: true)
               rescue JSON::ParserError => e
                 if %w(String Date Time).include?(return_type)
                   data = body

--- a/lib/hubspot/codegen/crm/commerce/invoices/api_client.rb
+++ b/lib/hubspot/codegen/crm/commerce/invoices/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/companies/api_client.rb
+++ b/lib/hubspot/codegen/crm/companies/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/contacts/api_client.rb
+++ b/lib/hubspot/codegen/crm/contacts/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/deals/api_client.rb
+++ b/lib/hubspot/codegen/crm/deals/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/exports/api_client.rb
+++ b/lib/hubspot/codegen/crm/exports/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/extensions/calling/api_client.rb
+++ b/lib/hubspot/codegen/crm/extensions/calling/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/extensions/cards/api_client.rb
+++ b/lib/hubspot/codegen/crm/extensions/cards/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/extensions/videoconferencing/api_client.rb
+++ b/lib/hubspot/codegen/crm/extensions/videoconferencing/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/imports/api_client.rb
+++ b/lib/hubspot/codegen/crm/imports/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/line_items/api_client.rb
+++ b/lib/hubspot/codegen/crm/line_items/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/lists/api_client.rb
+++ b/lib/hubspot/codegen/crm/lists/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/objects/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/objects/calls/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/calls/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/objects/communications/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/communications/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/objects/deal_splits/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/deal_splits/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/objects/emails/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/emails/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/objects/feedback_submissions/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/feedback_submissions/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/objects/goals/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/goals/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/objects/leads/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/leads/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/objects/meetings/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/meetings/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/objects/notes/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/notes/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/objects/postal_mail/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/postal_mail/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/objects/tasks/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/tasks/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/objects/taxes/api_client.rb
+++ b/lib/hubspot/codegen/crm/objects/taxes/api_client.rb
@@ -247,7 +247,7 @@ module Hubspot
             fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
             begin
-              data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+              data = JSON.parse(body, symbolize_names: true)
             rescue JSON::ParserError => e
               if %w(String Date Time).include?(return_type)
                 data = body

--- a/lib/hubspot/codegen/crm/owners/api_client.rb
+++ b/lib/hubspot/codegen/crm/owners/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/pipelines/api_client.rb
+++ b/lib/hubspot/codegen/crm/pipelines/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/products/api_client.rb
+++ b/lib/hubspot/codegen/crm/products/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/properties/api_client.rb
+++ b/lib/hubspot/codegen/crm/properties/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/quotes/api_client.rb
+++ b/lib/hubspot/codegen/crm/quotes/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/schemas/api_client.rb
+++ b/lib/hubspot/codegen/crm/schemas/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/tickets/api_client.rb
+++ b/lib/hubspot/codegen/crm/tickets/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/crm/timeline/api_client.rb
+++ b/lib/hubspot/codegen/crm/timeline/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/events/api_client.rb
+++ b/lib/hubspot/codegen/events/api_client.rb
@@ -245,7 +245,7 @@ module Hubspot
         fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
         begin
-          data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+          data = JSON.parse(body, symbolize_names: true)
         rescue JSON::ParserError => e
           if %w(String Date Time).include?(return_type)
             data = body

--- a/lib/hubspot/codegen/events/send/api_client.rb
+++ b/lib/hubspot/codegen/events/send/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/files/api_client.rb
+++ b/lib/hubspot/codegen/files/api_client.rb
@@ -245,7 +245,7 @@ module Hubspot
         fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
         begin
-          data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+          data = JSON.parse(body, symbolize_names: true)
         rescue JSON::ParserError => e
           if %w(String Date Time).include?(return_type)
             data = body

--- a/lib/hubspot/codegen/marketing/emails/api_client.rb
+++ b/lib/hubspot/codegen/marketing/emails/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/marketing/events/api_client.rb
+++ b/lib/hubspot/codegen/marketing/events/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/marketing/forms/api_client.rb
+++ b/lib/hubspot/codegen/marketing/forms/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/marketing/transactional/api_client.rb
+++ b/lib/hubspot/codegen/marketing/transactional/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/oauth/api_client.rb
+++ b/lib/hubspot/codegen/oauth/api_client.rb
@@ -244,7 +244,7 @@ module Hubspot
         fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
         begin
-          data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+          data = JSON.parse(body, symbolize_names: true)
         rescue JSON::ParserError => e
           if %w(String Date Time).include?(return_type)
             data = body

--- a/lib/hubspot/codegen/settings/business_units/api_client.rb
+++ b/lib/hubspot/codegen/settings/business_units/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/settings/users/api_client.rb
+++ b/lib/hubspot/codegen/settings/users/api_client.rb
@@ -246,7 +246,7 @@ module Hubspot
           fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
           begin
-            data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+            data = JSON.parse(body, symbolize_names: true)
           rescue JSON::ParserError => e
             if %w(String Date Time).include?(return_type)
               data = body

--- a/lib/hubspot/codegen/webhooks/api_client.rb
+++ b/lib/hubspot/codegen/webhooks/api_client.rb
@@ -245,7 +245,7 @@ module Hubspot
         fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 
         begin
-          data = JSON.parse("[#{body}]", :symbolize_names => true)[0]
+          data = JSON.parse(body, symbolize_names: true)
         rescue JSON::ParserError => e
           if %w(String Date Time).include?(return_type)
             data = body


### PR DESCRIPTION
Also cleanup `JSON.parse` calls, there is no need to wrap objects in an array, the `json` gem hasn't required this for over 15 years.